### PR TITLE
feat: update chatwoot

### DIFF
--- a/stacks/chatwoot.yml
+++ b/stacks/chatwoot.yml
@@ -28,7 +28,7 @@ x-defaults: &defaults
 services:
   web:
     <<: *defaults
-    image: chatwoot/chatwoot:${VERSION:-v4.0.4}
+    image: chatwoot/chatwoot:${VERSION:-v4.3.0}
     entrypoint: docker/entrypoints/rails.sh
     command: ['bundle', 'exec', 'rails', 's', '-p', '3000', '-b', '0.0.0.0']
     deploy:
@@ -45,7 +45,7 @@ services:
 
   sidekiq:
     <<: *defaults
-    image: chatwoot/chatwoot:${VERSION:-v4.0.4}
+    image: chatwoot/chatwoot:${VERSION:-v4.3.0}
     command: ['bundle', 'exec', 'sidekiq', '-C', 'config/sidekiq.yml']
     networks:
       - internal


### PR DESCRIPTION
Nous sommes utilisateurs de Chatwoot sur Ethibox.

Depuis quelque temps, nous avons un message qui nous invite à mettre à jour Chatwoot à la nouvelle version.

En consultant le changelog, je m’aperçois qu’il y a un breaking change si on n’utilise pas actuellement pgvector, ce qui semble être déjà le cas.

Voici donc une proposition d’upgrade de Chatwoot.

Bonne journée 